### PR TITLE
fix(type-fest): Update type-fest to fix dependency error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand-edx.org": "2.0.3",
-        "@edx/paragon": "^12.0.4",
+        "@edx/paragon": "^12.0.5",
         "babel-preset-minify": "^0.5.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.6.1",
+        "type-fest": "^2.14.0",
         "universal-cookie": "^4.0.0"
       },
       "devDependencies": {
@@ -2713,9 +2714,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.8.0.tgz",
-      "integrity": "sha512-gJVnozu4V1e2PCI0lFICvnrs2yi0ZzcaO5gJB9OjB1Pzf5GXpkKNWLtdTwjgp4fvzL9w4sqvyB30apbQzWW8yw==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.0.5.tgz",
+      "integrity": "sha512-5DhpXa1DktxOX2t7hdVBMYTWr0gn/30JKBq/ohjpCrnAbMfo6fM9MZkVlAtYKPmLOecxebL5ATTAKeP/T+WP3w==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -2731,7 +2732,6 @@
         "react-focus-on": "^3.5.0",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^6.1.1",
-        "react-table": "^7.6.1",
         "react-transition-group": "^4.0.0",
         "sanitize-html": "^1.20.0",
         "tabbable": "^4.0.0"
@@ -4874,62 +4874,6 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^12.4.0"
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
-      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-html": "^0.0.7",
-        "error-stack-parser": "^2.0.6",
-        "html-entities": "^1.2.1",
-        "native-url": "^0.2.6",
-        "schema-utils": "^2.6.5",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 10.x"
-      },
-      "peerDependencies": {
-        "@types/webpack": "4.x",
-        "react-refresh": ">=0.8.3 <0.10.0",
-        "sockjs-client": "^1.4.0",
-        "type-fest": "^0.13.1",
-        "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x",
-        "webpack-hot-middleware": "2.x",
-        "webpack-plugin-serve": "0.x || 1.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/webpack": {
-          "optional": true
-        },
-        "sockjs-client": {
-          "optional": true
-        },
-        "type-fest": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        },
-        "webpack-hot-middleware": {
-          "optional": true
-        },
-        "webpack-plugin-serve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7808,6 +7752,80 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "node_modules/@storybook/react/node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.x"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x",
+        "react-refresh": ">=0.8.3 <0.10.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": "^0.13.1",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@storybook/react/node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -8652,6 +8670,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@storybook/react/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/react/node_modules/watchpack": {
@@ -11892,6 +11924,15 @@
       "dependencies": {
         "has-flag": "^4.0.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15858,6 +15899,15 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -32161,18 +32211,6 @@
         "react": ">= 0.14.0"
       }
     },
-    "node_modules/react-table": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
-      }
-    },
     "node_modules/react-test-renderer": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
@@ -32309,6 +32347,15 @@
       "dependencies": {
         "p-limit": "^2.2.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -36772,12 +36819,14 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.14.0.tgz",
+      "integrity": "sha512-hQnTQkFjL5ik6HF2fTAM8ycbr94UbQXK364wF930VHb0dfBJ5JBP8qwrR8TaK9zwUEk7meruo2JAUDMwvuxd/w==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -41059,9 +41108,9 @@
       "requires": {}
     },
     "@edx/paragon": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.8.0.tgz",
-      "integrity": "sha512-gJVnozu4V1e2PCI0lFICvnrs2yi0ZzcaO5gJB9OjB1Pzf5GXpkKNWLtdTwjgp4fvzL9w4sqvyB30apbQzWW8yw==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-12.0.5.tgz",
+      "integrity": "sha512-5DhpXa1DktxOX2t7hdVBMYTWr0gn/30JKBq/ohjpCrnAbMfo6fM9MZkVlAtYKPmLOecxebL5ATTAKeP/T+WP3w==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -41077,7 +41126,6 @@
         "react-focus-on": "^3.5.0",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^6.1.1",
-        "react-table": "^7.6.1",
         "react-transition-group": "^4.0.0",
         "sanitize-html": "^1.20.0",
         "tabbable": "^4.0.0"
@@ -42770,28 +42818,6 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^12.4.0"
-      }
-    },
-    "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
-      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
-      "dev": true,
-      "requires": {
-        "ansi-html": "^0.0.7",
-        "error-stack-parser": "^2.0.6",
-        "html-entities": "^1.2.1",
-        "native-url": "^0.2.6",
-        "schema-utils": "^2.6.5",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-          "dev": true
-        }
       }
     },
     "@popperjs/core": {
@@ -45165,6 +45191,39 @@
             "@babel/highlight": "^7.8.3"
           }
         },
+        "@pmmmwh/react-refresh-webpack-plugin": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+          "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+          "dev": true,
+          "requires": {
+            "ansi-html": "^0.0.7",
+            "error-stack-parser": "^2.0.6",
+            "html-entities": "^1.2.1",
+            "native-url": "^0.2.6",
+            "schema-utils": "^2.6.5",
+            "source-map": "^0.7.3"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+              "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.5",
+                "ajv": "^6.12.4",
+                "ajv-keywords": "^3.5.2"
+              }
+            },
+            "source-map": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+              "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+              "dev": true
+            }
+          }
+        },
         "@webassemblyjs/ast": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -45868,6 +45927,14 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
+        },
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "watchpack": {
           "version": "1.7.5",
@@ -48641,6 +48708,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -51568,6 +51641,12 @@
           "requires": {
             "minimist": "^1.2.6"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -64364,12 +64443,6 @@
         "refractor": "^3.1.0"
       }
     },
-    "react-table": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "requires": {}
-    },
     "react-test-renderer": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
@@ -64504,6 +64577,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -68047,10 +68126,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.14.0.tgz",
+      "integrity": "sha512-hQnTQkFjL5ik6HF2fTAM8ycbr94UbQXK364wF930VHb0dfBJ5JBP8qwrR8TaK9zwUEk7meruo2JAUDMwvuxd/w=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
   },
   "dependencies": {
     "@edx/brand-edx.org": "2.0.3",
-    "@edx/paragon": "^12.0.4",
+    "@edx/paragon": "^12.0.5",
     "babel-preset-minify": "^0.5.0",
     "classnames": "^2.3.1",
     "prop-types": "^15.6.1",
+    "type-fest": "^2.14.0",
     "universal-cookie": "^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This works around a dependency error which started with node 16.15.1. I found this thread: https://github.com/zooniverse/Panoptes-Front-End/issues/6155

There was an error about incompatible `type-fest` dependencies: https://github.com/openedx/frontend-component-cookie-policy-banner/runs/7076759822?check_suite_focus=true. This PR upgrades to the latest `type-fest` to resolve those dependencies. Since this package is only used by dev dependencies it shouldn't have any impact on the end user