### PR TITLE
fix(build): use compile-prod for build command

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
       run: npm ci
 
     - name: Create Build
-      run: npm run build
+      run: npm run compile-prod
 
     - name: Release Package
       env:


### PR DESCRIPTION
Use `npm run compile-prod` for the build command. This is what the old Travis script used before #374 migrated to github actions