### PR TITLE
fix(deploy): deploy from master so that we can publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: node_js CI
 
 on:
-  push:
-    branches:
-    - master
   pull_request:
     branches:
     - '**'
@@ -40,3 +37,14 @@ jobs:
 
     - name: Run Coverage
       uses: codecov/codecov-action@v2
+
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+
+    - name: Preview semantic-release version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+      run: npm run semantic-release --dry-run --branches=${{ steps.extract_branch.outputs.branch}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,8 @@
 name: Release CI
 on:
   push:
-    tags:
-    - '*'
+    branches:
+    - master
 
 jobs:
   release:
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v1
@@ -22,8 +23,20 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Lint
+      run: npm run lint
+
+    - name: Test
+      run: npm run test
+
     - name: Create Build
       run: npm run compile-prod
+
+    - name: Verify es5
+      run: npm run is-es5
+
+    - name: Run Coverage
+      uses: codecov/codecov-action@v2
 
     - name: Release Package
       env:


### PR DESCRIPTION
The deploy worked but it was ignored because we were publishing off of a tag. This PR changes the workflow to deploy from master instead, and run CI-related steps like linting and unit tests. I adapted what we are currently doing on paragon for this PR