### PR TITLE
feat(treeshaking): Update package to output es6 module, to allow for treeshaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Compile
       run: npm run compile-prod
 
-    - name: Verify es5
-      run: npm run is-es5
-
     - name: Run Coverage
       uses: codecov/codecov-action@v2
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Create Build
       run: npm run compile-prod
 
-    - name: Verify es5
-      run: npm run is-es5
-
     - name: Run Coverage
       uses: codecov/codecov-action@v2
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,11 +1,19 @@
 {
   "presets": [
-    "@babel/preset-env",
+    [
+      "@babel/preset-env",
+      {
+        "modules": false
+      }
+    ],
     "@babel/preset-react"
   ],
   "env": {
-    "production": {
-      "presets": ["minify"]
+    "test": {
+      "presets": [
+        "@babel/preset-env",
+        "@babel/preset-react"
+      ]
     }
   }
 }


### PR DESCRIPTION
In order to make treeshaking work we need to output es6 modules. paragon made a similar change in this PR: https://github.com/openedx/paragon/pull/481. This PR adjusts babel.config.json similarly