### PR TITLE
docs: Update the security e-mail address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,5 @@ locally builds the Storybook for the `CookiePolicyBanner` component on port `300
 You can contact the edx open-source team at oscm@edx.org.
 
 ## Security reporting information
-Please do not report security issues in public. Send security concerns via email to security@edx.org.
+Please do not report security issues in public. Send security concerns via email to security@openedx.org.
 


### PR DESCRIPTION
This repository is now managed by the Axim Collaborative and security issues
with it should be reported to security@openedx.org instead of security@edx.org

This work is being done as a part of https://github.com/openedx/wg-security/issues/16
